### PR TITLE
Introduce the new OpenID 2.0 authentication middleware for ASP.NET 5

### DIFF
--- a/AspNet.Security.OpenId.Providers.sln
+++ b/AspNet.Security.OpenId.Providers.sln
@@ -7,8 +7,23 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EFBB5EFD-334
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{8D5ED59A-C3FC-4E35-9E73-A8FF5492DFCD}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNet.Security.OpenId", "src\AspNet.Security.OpenId\AspNet.Security.OpenId.xproj", "{9254C4F1-2305-457F-A7DB-9BEE8B2A76B7}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9254C4F1-2305-457F-A7DB-9BEE8B2A76B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9254C4F1-2305-457F-A7DB-9BEE8B2A76B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9254C4F1-2305-457F-A7DB-9BEE8B2A76B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9254C4F1-2305-457F-A7DB-9BEE8B2A76B7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9254C4F1-2305-457F-A7DB-9BEE8B2A76B7} = {EFBB5EFD-334C-487E-8C31-9F21FB106FFF}
 	EndGlobalSection
 EndGlobal

--- a/src/AspNet.Security.OpenId/AspNet.Security.OpenId.xproj
+++ b/src/AspNet.Security.OpenId/AspNet.Security.OpenId.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9254c4f1-2305-457f-a7db-9bee8b2a76b7</ProjectGuid>
+    <RootNamespace>AspNet.Security.OpenId</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/AspNet.Security.OpenId/IOpenIdAuthenticationProvider.cs
+++ b/src/AspNet.Security.OpenId/IOpenIdAuthenticationProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+using AspNet.Security.OpenId.Notifications;
+
+namespace AspNet.Security.OpenId {
+    public interface IOpenIdAuthenticationProvider {
+        Task Authenticated(OpenIdAuthenticatedNotification notification);
+        Task ReturnEndpoint(OpenIdReturnEndpointNotification notification);
+    }
+}

--- a/src/AspNet.Security.OpenId/Notifications/OpenIdAuthenticatedNotification.cs
+++ b/src/AspNet.Security.OpenId/Notifications/OpenIdAuthenticatedNotification.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Security.Claims;
+using Microsoft.AspNet.Authentication.Notifications;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Authentication;
+using Microsoft.Framework.Internal;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OpenId.Notifications {
+    public class OpenIdAuthenticatedNotification : BaseNotification<OpenIdAuthenticationOptions> {
+        public OpenIdAuthenticatedNotification(
+            [NotNull] HttpContext context,
+            [NotNull] OpenIdAuthenticationOptions options)
+            : base(context, options) {
+        }
+
+        public ClaimsPrincipal Principal { get; set; }
+
+        public AuthenticationProperties Properties { get; set; }
+
+        public string Identifier { get; [param: NotNull] set; }
+
+        public IReadOnlyDictionary<string, string> Attributes { get; [param: NotNull] set; } = ImmutableDictionary.Create<string, string>();
+
+        public JObject User { get; [param: NotNull] set; } = new JObject();
+    }
+}

--- a/src/AspNet.Security.OpenId/Notifications/OpenIdReturnEndpointNotification.cs
+++ b/src/AspNet.Security.OpenId/Notifications/OpenIdReturnEndpointNotification.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Authentication.Notifications;
+using Microsoft.AspNet.Http;
+using Microsoft.Framework.Internal;
+
+namespace AspNet.Security.OpenId.Notifications {
+    /// <summary>
+    /// Provides context information to middleware providers.
+    /// </summary>
+    public class OpenIdReturnEndpointNotification : ReturnEndpointContext {
+        /// <summary>
+        /// Initializes a <see cref="OpenIdReturnEndpointNotification"/>
+        /// </summary>
+        /// <param name="context">The <see cref="HttpContext"/> corresponding to the current request.</param>
+        /// <param name="ticket">The authentication ticket.</param>
+        public OpenIdReturnEndpointNotification(
+            [NotNull] HttpContext context,
+            [NotNull] AuthenticationTicket ticket)
+            : base(context, ticket) {
+        }
+    }
+}

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationConstants.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationConstants.cs
@@ -1,0 +1,49 @@
+﻿namespace AspNet.Security.OpenId {
+    internal static class OpenIdAuthenticationConstants {
+        public static class Aliases {
+            public const string Ax = "ax";
+        }
+
+        public static class Prefixes {
+            public const string OpenId = "openid.";
+            public const string Namespace = "ns.";
+            public const string Ax = "ax.";
+            public const string Type = "type.";
+        }
+
+        public static class Suffixes {
+            public const string Type = ".type";
+        }
+
+        public static class Parameters {
+            public const string Namespace = "ns";
+            public const string Mode = "mode";
+            public const string IsValid = "is_valid";
+            public const string ReturnTo = "return_to";
+            public const string ClaimedId = "claimed_id";
+            public const string Identity = "identity";
+            public const string Realm = "realm";
+            public const string Required = "required";
+            public const string State = "state";
+        }
+
+        public static class Namespaces {
+            public const string OpenId = "http://specs.openid.net/auth/2.0";
+            public const string Ax = "http://openid.net/srv/ax/1.0";
+        }
+
+        public static class Modes {
+            public const string IdRes = "id_res";
+            public const string CheckIdSetup = "checkid_setup";
+            public const string CheckAuthentication = "check_authentication";
+            public const string FetchRequest = "fetch_request";
+        }
+
+        public static class Attributes {
+            public const string Email = "http://axschema.org/contact/email";
+            public const string Name = "http://axschema.org/namePerson";
+            public const string Firstname = "http://axschema.org/namePerson/first";
+            public const string Lastname = "http://axschema.org/namePerson/last";
+        }
+    }
+}

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationDefaults.cs
@@ -1,0 +1,5 @@
+﻿namespace AspNet.Security.OpenId {
+    public static class OpenIdAuthenticationDefaults {
+        public const string AuthenticationScheme = "OpenId";
+    }
+}

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using AspNet.Security.OpenId;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Internal;
+using Microsoft.Framework.OptionsModel;
+
+namespace Microsoft.AspNet.Builder {
+    public static class OpenIdAuthenticationExtensions {
+        public static IServiceCollection ConfigureOpenIdAuthentication(
+            [NotNull] this IServiceCollection services, [NotNull] string scheme,
+            [NotNull] Action<OpenIdAuthenticationOptions> configuration) {
+            return services.Configure<OpenIdAuthenticationOptions>(options => {
+                options.AuthenticationScheme = scheme;
+                options.Caption = scheme;
+
+                configuration(options);
+            }, scheme);
+        }
+
+        public static IApplicationBuilder UseOpenIdAuthentication(
+            [NotNull] this IApplicationBuilder app, [NotNull] string scheme) {
+            return app.UseMiddleware<OpenIdAuthenticationMiddleware<OpenIdAuthenticationOptions>>(
+                new ConfigureOptions<OpenIdAuthenticationOptions>(options => {
+                    options.AuthenticationScheme = scheme;
+                    options.Caption = scheme;
+                }) { Name = scheme });
+        }
+
+        public static IApplicationBuilder UseOpenIdAuthentication(
+            [NotNull] this IApplicationBuilder app, [NotNull] string scheme,
+            [NotNull] Action<OpenIdAuthenticationOptions> configuration) {
+            return app.UseMiddleware<OpenIdAuthenticationMiddleware<OpenIdAuthenticationOptions>>(
+                new ConfigureOptions<OpenIdAuthenticationOptions>(options => {
+                    options.AuthenticationScheme = scheme;
+                    options.Caption = scheme;
+
+                    configuration(options);
+                }) { Name = scheme });
+        }
+    }
+}

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
@@ -1,0 +1,581 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Authentication.DataHandler.Encoder;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Authentication;
+using Microsoft.AspNet.Http.Features.Authentication;
+using Microsoft.AspNet.WebUtilities;
+using Microsoft.Framework.Internal;
+using Microsoft.Framework.Logging;
+using System.Collections.Immutable;
+using AspNet.Security.OpenId.Notifications;
+
+#if DNX451
+using CsQuery;
+#endif
+
+namespace AspNet.Security.OpenId {
+    public class OpenIdAuthenticationHandler<TOptions> : AuthenticationHandler<TOptions> where TOptions : OpenIdAuthenticationOptions {
+        protected override async Task<AuthenticationTicket> HandleAuthenticateAsync() {
+            AuthenticationProperties properties = null;
+
+            try {
+                // Always extract the "state" parameter from the query string.
+                var state = Request.Query[OpenIdAuthenticationConstants.Parameters.State];
+                if (string.IsNullOrEmpty(state)) {
+                    return null;
+                }
+
+                properties = Options.StateDataFormat.Unprotect(state);
+                if (properties == null) {
+                    Logger.LogWarning("The authentication response was rejected " +
+                                      "because it contained an invalid state.");
+
+                    return null;
+                }
+
+                // Validate the anti-forgery token.
+                if (!ValidateCorrelationId(properties)) {
+                    return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                }
+
+                IReadableStringCollection message;
+
+                // OpenID 2.0 responses MUST necessarily be made using either GET or POST.
+                // See http://openid.net/specs/openid-authentication-2_0.html#anchor4
+                if (!string.Equals(Request.Method, "GET", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(Request.Method, "POST", StringComparison.OrdinalIgnoreCase)) {
+                    Logger.LogWarning("The authentication response was rejected because it was made" +
+                                      "using an invalid method: make sure to use either GET or POST.");
+
+                    return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                }
+
+                if (string.Equals(Request.Method, "GET", StringComparison.OrdinalIgnoreCase)) {
+                    message = Request.Query;
+                }
+
+                else {
+                    // OpenID 2.0 responses MUST include a Content-Type header when using POST.
+                    // See http://openid.net/specs/openid-authentication-2_0.html#anchor4
+                    if (string.IsNullOrEmpty(Request.ContentType)) {
+                        Logger.LogWarning("The authentication response was rejected because " +
+                                          "it was missing the mandatory 'Content-Type' header.");
+
+                        return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                    }
+
+                    // May have media/type; charset=utf-8, allow partial match.
+                    if (!Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase)) {
+                        Logger.LogWarning("The authentication response was rejected because an invalid Content-Type header " +
+                                          "was received: make sure to use 'application/x-www-form-urlencoded'.");
+
+                        return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                    }
+
+                    message = await Request.ReadFormAsync();
+                }
+
+                // Ensure that the current request corresponds to an OpenID 2.0 assertion.
+                if (!string.Equals(message[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                                           OpenIdAuthenticationConstants.Parameters.Namespace],
+                                   OpenIdAuthenticationConstants.Namespaces.OpenId, StringComparison.Ordinal)) {
+                    Logger.LogWarning("The authentication response was rejected because it was missing the mandatory" +
+                                      "'openid.ns' parameter or because an unsupported version of OpenID was used.");
+
+                    return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                }
+
+                // Stop processing the message if the assertion was not positive.
+                if (!string.Equals(message[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                                           OpenIdAuthenticationConstants.Parameters.Mode],
+                                   OpenIdAuthenticationConstants.Modes.IdRes, StringComparison.Ordinal)) {
+                    Logger.LogWarning("The authentication response was rejected because " +
+                                      "the identity provider declared it as invalid.");
+
+                    return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                }
+
+                // Stop processing the message if the assertion
+                // was not validated by the identity provider.
+                if (!await VerifyAssertionAsync(message)) {
+                    return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                }
+
+                // Validate the return_to parameter by comparing it to the address stored in the properties.
+                // See http://openid.net/specs/openid-authentication-2_0.html#verify_return_to
+                var address = QueryHelpers.AddQueryString(uri: properties.Items[OpenIdAuthenticationConstants.Parameters.ReturnTo],
+                                                          name: OpenIdAuthenticationConstants.Parameters.State, value: state);
+                if (!string.Equals(message[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                                           OpenIdAuthenticationConstants.Parameters.ReturnTo], address, StringComparison.Ordinal)) {
+                    Logger.LogWarning("The authentication response was rejected because the return_to parameter was invalid.");
+
+                    return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                }
+
+                // Create a new dictionary containing the extensions found in the assertion.
+                var prefix = OpenIdAuthenticationConstants.Prefixes.OpenId + OpenIdAuthenticationConstants.Prefixes.Namespace;
+                var extensions = message.Where(parameter => parameter.Key.StartsWith(prefix, StringComparison.Ordinal))
+                                        .ToDictionary(parameter => parameter.Value.FirstOrDefault(),
+                                                      parameter => parameter.Key.Substring(prefix.Length));
+
+                // Make sure the OpenID 2.0 assertion contains an identifier.
+                var identifier = message[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                                         OpenIdAuthenticationConstants.Parameters.ClaimedId];
+                if (string.IsNullOrEmpty(identifier)) {
+                    Logger.LogWarning("The authentication response was rejected because it " +
+                                      "was missing the mandatory 'claimed_id' parameter.");
+
+                    return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+                }
+
+                var identity = new ClaimsIdentity(Options.AuthenticationScheme);
+
+                // Add the claimed identifier to the identity. 
+                identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, identifier, ClaimValueTypes.String, Options.ClaimsIssuer));
+
+                // Create a new dictionary containing the optional attributes extracted from the assertion.
+                var attributes = new Dictionary<string, string>(StringComparer.Ordinal);
+
+                // Determine whether attribute exchange has been enabled.
+                string alias;
+                if (extensions.TryGetValue(OpenIdAuthenticationConstants.Namespaces.Ax, out alias)) {
+                    foreach (var parameter in message) {
+                        // Exclude parameters that don't correspond to the attribute exchange alias.
+                        if (!parameter.Key.StartsWith(OpenIdAuthenticationConstants.Prefixes.OpenId + alias +
+                                                      OpenIdAuthenticationConstants.Suffixes.Type, StringComparison.Ordinal)) {
+                            continue;
+                        }
+
+                        // Exclude attributes whose alias is malformed.
+                        var name = parameter.Key.Substring($"openid.{alias}.type.".Length);
+                        if (string.IsNullOrEmpty(name)) {
+                            continue;
+                        }
+
+                        // Exclude attributes whose type is missing.
+                        var type = parameter.Value.FirstOrDefault();
+                        if (string.IsNullOrEmpty(type)) {
+                            continue;
+                        }
+
+                        // Exclude attributes whose value is missing.
+                        var value = message.Get($"openid.{alias}.value.{name}");
+                        if (string.IsNullOrEmpty(value)) {
+                            continue;
+                        }
+
+                        attributes.Add(type, value);
+                    }
+
+                    // Add the most common attributes to the identity.
+                    foreach (var attribute in attributes) {
+                        // http://axschema.org/contact/email
+                        if (string.Equals(attribute.Key, OpenIdAuthenticationConstants.Attributes.Email, StringComparison.Ordinal)) {
+                            identity.AddClaim(new Claim(ClaimTypes.Email, attribute.Value, ClaimValueTypes.Email, Options.ClaimsIssuer));
+                        }
+
+                        // http://axschema.org/namePerson
+                        else if (string.Equals(attribute.Key, OpenIdAuthenticationConstants.Attributes.Name, StringComparison.Ordinal)) {
+                            identity.AddClaim(new Claim(ClaimTypes.Name, attribute.Value, ClaimValueTypes.String, Options.ClaimsIssuer));
+                        }
+
+                        // http://axschema.org/namePerson/first
+                        else if (string.Equals(attribute.Key, OpenIdAuthenticationConstants.Attributes.Firstname, StringComparison.Ordinal)) {
+                            identity.AddClaim(new Claim(ClaimTypes.GivenName, attribute.Value, ClaimValueTypes.String, Options.ClaimsIssuer));
+                        }
+
+                        // http://axschema.org/namePerson/last
+                        else if (string.Equals(attribute.Key, OpenIdAuthenticationConstants.Attributes.Lastname, StringComparison.Ordinal)) {
+                            identity.AddClaim(new Claim(ClaimTypes.Surname, attribute.Value, ClaimValueTypes.String, Options.ClaimsIssuer));
+                        }
+                    }
+
+                    // Create a ClaimTypes.Name claim using ClaimTypes.GivenName and ClaimTypes.Surname
+                    // if the http://axschema.org/namePerson attribute cannot be found in the assertion.
+                    if (!identity.HasClaim(claim => string.Equals(claim.Type, ClaimTypes.Name, StringComparison.OrdinalIgnoreCase)) &&
+                         identity.HasClaim(claim => string.Equals(claim.Type, ClaimTypes.GivenName, StringComparison.OrdinalIgnoreCase)) &&
+                         identity.HasClaim(claim => string.Equals(claim.Type, ClaimTypes.Surname, StringComparison.OrdinalIgnoreCase))) {
+                        identity.AddClaim(new Claim(ClaimTypes.Name, $"{identity.FindFirst(ClaimTypes.GivenName).Value} " +
+                                                                     $"{identity.FindFirst(ClaimTypes.Surname).Value}",
+                                                    ClaimValueTypes.String, Options.ClaimsIssuer));
+                    }
+                }
+
+                return await CreateTicketAsync(identity, properties, identifier, attributes);
+            }
+
+            catch (Exception exception) {
+                Logger.LogError("Authentication failed due to an unknown exception.", exception);
+
+                return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+            }
+        }
+
+        protected virtual async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity, [NotNull] AuthenticationProperties properties,
+            [NotNull] string identifier, [NotNull] IDictionary<string, string> attributes) {
+            var notification = new OpenIdAuthenticatedNotification(Context, Options) {
+                Attributes = attributes.ToImmutableDictionary(),
+                Principal = new ClaimsPrincipal(identity),
+                Properties = properties,
+                Identifier = identifier
+            };
+
+            await Options.Provider.Authenticated(notification);
+
+            if (notification.Principal?.Identity == null) {
+                return new AuthenticationTicket(properties, Options.AuthenticationScheme);
+            }
+
+            return new AuthenticationTicket(notification.Principal, notification.Properties, Options.AuthenticationScheme);
+        }
+
+        protected override async Task<bool> HandleUnauthorizedAsync(ChallengeContext context) {
+            var properties = new AuthenticationProperties(context.Properties);
+
+            if (string.IsNullOrEmpty(Options.Endpoint)) {
+                // Note: altering options during a request is not thread safe but
+                // would only result in multiple discovery requests in the worst case.
+                Options.Endpoint = await DiscoverEndpointAsync(Options.Authority);
+            }
+
+            if (string.IsNullOrEmpty(Options.Endpoint)) {
+                Logger.LogError("The user agent cannot be redirected to the identity provider because no " +
+                                "endpoint was registered in the options or discovered through Yadis.");
+
+                return true;
+            }
+
+            // Determine the realm using the current address
+            // if one has not been explicitly provided;
+            var realm = Options.Realm;
+            if (string.IsNullOrEmpty(realm)) {
+                realm = Request.Scheme + "://" + Request.Host + OriginalPathBase;
+            }
+
+            // Use the current address as the final location where the user agent
+            // will be redirected to if one has not been explicitly provided.
+            if (string.IsNullOrEmpty(properties.RedirectUri)) {
+                properties.RedirectUri = Request.Scheme + "://" + Request.Host +
+                                         OriginalPathBase + Request.Path + Request.QueryString;
+            }
+
+            // Store the return_to parameter for later comparison.
+            properties.Items[OpenIdAuthenticationConstants.Parameters.ReturnTo] =
+                Request.Scheme + "://" + Request.Host +
+                OriginalPathBase + Options.CallbackPath;
+
+            // Generate a new anti-forgery token.
+            GenerateCorrelationId(properties);
+
+            var state = UrlEncoder.UrlEncode(Options.StateDataFormat.Protect(properties));
+
+            // Create a new dictionary containing the OpenID 2.0 request parameters.
+            // See http://openid.net/specs/openid-authentication-2_0.html#requesting_authentication
+            var parameters = new Dictionary<string, string> {
+                // openid.ns (http://specs.openid.net/auth/2.0)
+                [OpenIdAuthenticationConstants.Prefixes.OpenId +
+                 OpenIdAuthenticationConstants.Parameters.Namespace] = OpenIdAuthenticationConstants.Namespaces.OpenId,
+
+                // openid.mode (checkid_setup)
+                [OpenIdAuthenticationConstants.Prefixes.OpenId +
+                 OpenIdAuthenticationConstants.Parameters.Mode] = OpenIdAuthenticationConstants.Modes.CheckIdSetup,
+
+                // openid.claimed_id (http://specs.openid.net/auth/2.0/identifier_select)
+                [OpenIdAuthenticationConstants.Prefixes.OpenId +
+                 OpenIdAuthenticationConstants.Parameters.ClaimedId] = "http://specs.openid.net/auth/2.0/identifier_select",
+
+                // openid.identity (http://specs.openid.net/auth/2.0/identifier_select)
+                [OpenIdAuthenticationConstants.Prefixes.OpenId +
+                 OpenIdAuthenticationConstants.Parameters.Identity] = "http://specs.openid.net/auth/2.0/identifier_select",
+
+                // openid.return_to
+                [OpenIdAuthenticationConstants.Prefixes.OpenId +
+                 OpenIdAuthenticationConstants.Parameters.ReturnTo] = QueryHelpers.AddQueryString(
+                     properties.Items[OpenIdAuthenticationConstants.Parameters.ReturnTo], "state", state),
+
+                // openid_realm
+                [OpenIdAuthenticationConstants.Prefixes.OpenId + OpenIdAuthenticationConstants.Parameters.Realm] = realm
+            };
+
+            if (Options.Attributes.Any()) {
+                // openid.ns.ax (http://openid.net/srv/ax/1.0)
+                parameters[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                           OpenIdAuthenticationConstants.Prefixes.Namespace +
+                           OpenIdAuthenticationConstants.Aliases.Ax] = OpenIdAuthenticationConstants.Namespaces.Ax;
+
+                // openid.ax.mode (fetch_request)
+                parameters[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                           OpenIdAuthenticationConstants.Prefixes.Ax +
+                           OpenIdAuthenticationConstants.Parameters.Mode] = OpenIdAuthenticationConstants.Modes.FetchRequest;
+
+                foreach (var attribute in Options.Attributes) {
+                    parameters[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                               OpenIdAuthenticationConstants.Prefixes.Ax +
+                               OpenIdAuthenticationConstants.Prefixes.Type + attribute.Key] = attribute.Value;
+                }
+
+                // openid.ax.required
+                parameters[OpenIdAuthenticationConstants.Prefixes.OpenId +
+                           OpenIdAuthenticationConstants.Prefixes.Ax +
+                           OpenIdAuthenticationConstants.Parameters.Required] = string.Join(",", Options.Attributes.Select(attribute => attribute.Key));
+            }
+
+            Response.Redirect(await GenerateChallengeUrlAsync(parameters));
+
+            return true;
+        }
+
+        protected virtual Task<string> GenerateChallengeUrlAsync([NotNull] IDictionary<string, string> parameters) {
+            return Task.FromResult(QueryHelpers.AddQueryString(Options.Endpoint, parameters));
+        }
+
+        protected virtual async Task<string> DiscoverEndpointAsync([NotNull] Uri address) {
+            // application/xrds+xml MUST be the preferred content type to avoid a second round-trip.
+            // See http://openid.net/specs/yadis-v1.0.pdf (chapter 6.2.4)
+            var request = new HttpRequestMessage(HttpMethod.Get, address);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xrds+xml"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xhtml+xml"));
+
+            var response = await Options.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
+            if (!response.IsSuccessStatusCode) {
+                Logger.LogWarning("The Yadis discovery failed because an invalid response was returned by the identity provider.");
+
+                return null;
+            }
+
+            // Note: application/xrds+xml is the standard content type but text/xml is frequent.
+            // See http://openid.net/specs/yadis-v1.0.pdf (chapter 6.2.6)
+            if (string.Equals(response.Content.Headers.ContentType?.MediaType, "application/xrds+xml") ||
+                string.Equals(response.Content.Headers.ContentType?.MediaType, "text/xml")) {
+                using (var stream = await response.Content.ReadAsStreamAsync())
+                using (var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true })) {
+                    var document = XDocument.Load(reader);
+
+                    var endpoint = (from service in document.Root.Element(XName.Get("XRD", "xri://$xrd*($v*2.0)"))
+                                                                 .Descendants(XName.Get("Service", "xri://$xrd*($v*2.0)"))
+                                    where service.Descendants(XName.Get("Type", "xri://$xrd*($v*2.0)"))
+                                                 .Any(type => type.Value == "http://specs.openid.net/auth/2.0/server")
+                                    orderby service.Attribute("priority")?.Value
+                                    select service.Element(XName.Get("URI", "xri://$xrd*($v*2.0)"))?.Value).FirstOrDefault();
+
+                    if (!string.IsNullOrEmpty(endpoint)) {
+                        return endpoint;
+                    }
+
+                    Logger.LogWarning("The Yadis discovery failed because the XRDS document returned by the" +
+                                      "identity provider was invalid or didn't contain the endpoint address.");
+
+                    return null;
+                }
+            }
+
+            // Try to extract the XRDS location from the response headers before parsing the body.
+            // See http://openid.net/specs/yadis-v1.0.pdf (chapter 6.2.6)
+            var location = (from header in response.Headers
+                            where string.Equals(header.Key, "X-XRDS-Location", StringComparison.OrdinalIgnoreCase)
+                            from value in header.Value
+                            select value).FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(location)) {
+                if (!Uri.TryCreate(location, UriKind.Absolute, out address) &&
+                    !Uri.TryCreate(Options.Authority, location, out address)) {
+                    Logger.LogWarning("The Yadis discovery failed because the X-XRDS-Location " +
+                                      "header returned by the identity provider was invalid.");
+
+                    return null;
+                }
+
+                return await DiscoverEndpointAsync(address);
+            }
+
+#if DNX451
+            // Only text/html or application/xhtml+xml can be safely parsed.
+            // See http://openid.net/specs/yadis-v1.0.pdf
+            if (string.Equals(response.Content.Headers.ContentType?.MediaType, "text/html") ||
+                string.Equals(response.Content.Headers.ContentType?.MediaType, "application/xhtml+xml")) {
+                var document = CQ.CreateDocument(await response.Content.ReadAsStringAsync());
+
+                // Use LINQ instead of a CSS selector
+                // to execute a case-insensitive search.
+                var endpoint = (from meta in document.Find("meta")
+                                where string.Equals(meta.Attributes["http-equiv"], "X-XRDS-Location", StringComparison.OrdinalIgnoreCase)
+                                select meta.Attributes["content"]).FirstOrDefault();
+
+                if (!string.IsNullOrEmpty(endpoint)) {
+                    return endpoint;
+                }
+            }
+#endif
+
+            Logger.LogWarning("The Yadis discovery failed because the XRDS document location was not found.");
+
+            return null;
+        }
+
+        protected virtual async Task<bool> VerifyAssertionAsync([NotNull] IReadableStringCollection message) {
+            // Create a new dictionary to store the parameters sent to the identity provider.
+            // Note: using a dictionary is safe as OpenID 2.0 parameters are supposed to be unique.
+            // See http://openid.net/specs/openid-authentication-2_0.html#anchor4
+            var payload = new Dictionary<string, string> {
+                [OpenIdAuthenticationConstants.Prefixes.OpenId +
+                 OpenIdAuthenticationConstants.Parameters.Mode] = OpenIdAuthenticationConstants.Modes.CheckAuthentication
+            };
+
+            // Copy the parameters extracted from the assertion.
+            foreach (var parameter in message) {
+                if (string.Equals(parameter.Key, OpenIdAuthenticationConstants.Prefixes.OpenId +
+                                                 OpenIdAuthenticationConstants.Parameters.Mode, StringComparison.Ordinal)) {
+                    continue;
+                }
+
+                payload.Add(parameter.Key, parameter.Value.FirstOrDefault());
+            }
+
+            // Create a new check_authentication request to verify the assertion.
+            var request = new HttpRequestMessage(HttpMethod.Post, Options.Endpoint);
+            request.Content = new FormUrlEncodedContent(payload);
+
+            var response = await Options.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
+            if (!response.IsSuccessStatusCode) {
+                Logger.LogWarning("The authentication response was rejected because the identity provider" +
+                                  "returned an invalid check_authentication response.");
+
+                return false;
+            }
+
+            using (var stream = await response.Content.ReadAsStreamAsync())
+            using (var reader = new StreamReader(stream)) {
+                // Create a new dictionary containing the parameters extracted from the response body.
+                var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+
+                // Note: the response is encoded using the 'Key-Value Form Encoding'.
+                // See http://openid.net/specs/openid-authentication-2_0.html#anchor4
+                for (var line = await reader.ReadLineAsync(); !string.IsNullOrEmpty(line); line = await reader.ReadLineAsync()) {
+                    var parameter = line.Split(':');
+                    if (parameter.Length != 2) {
+                        continue;
+                    }
+
+                    parameters.Add(parameter[0], parameter[1]);
+                }
+
+                // Stop processing the assertion if the mandatory is_valid
+                // parameter was missing from the response body.
+                if (!parameters.ContainsKey(OpenIdAuthenticationConstants.Parameters.IsValid)) {
+                    Logger.LogWarning("The authentication response was rejected because the identity provider" +
+                                      "returned an invalid check_authentication response.");
+
+                    return false;
+                }
+
+                // Stop processing the assertion if the authentication server declared it as invalid.
+                if (!string.Equals(parameters[OpenIdAuthenticationConstants.Parameters.IsValid], "true", StringComparison.Ordinal)) {
+                    Logger.LogWarning("The authentication response was rejected because the identity provider" +
+                                      "declared the security assertion as invalid.");
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override async Task<bool> InvokeAsync() {
+            if (Options.CallbackPath.HasValue && Options.CallbackPath == Request.Path) {
+                var ticket = await HandleAuthenticateOnceAsync();
+                if (ticket == null) {
+                    Logger.LogWarning("Invalid return state, unable to redirect.");
+
+                    Response.StatusCode = 500;
+                    return true;
+                }
+
+                var context = new OpenIdReturnEndpointNotification(Context, ticket) {
+                    SignInScheme = Options.SignInScheme,
+                    RedirectUri = ticket.Properties.RedirectUri,
+                };
+
+                ticket.Properties.RedirectUri = null;
+
+                await Options.Provider.ReturnEndpoint(context);
+
+                if (context.SignInScheme != null && context.Principal != null) {
+                    await Context.Authentication.SignInAsync(context.SignInScheme, context.Principal, context.Properties);
+                }
+
+                if (!context.IsRequestCompleted && context.RedirectUri != null) {
+                    if (context.Principal == null) {
+                        context.RedirectUri = QueryHelpers.AddQueryString(context.RedirectUri, "error", "access_denied");
+                    }
+
+                    Response.Redirect(context.RedirectUri);
+                    context.RequestCompleted();
+                }
+
+                return context.IsRequestCompleted;
+            }
+
+            return false;
+        }
+
+        protected void GenerateCorrelationId([NotNull] AuthenticationProperties properties) {
+            var correlationKey = "security.Authenticate" + Options.AuthenticationScheme;
+
+            var nonceBytes = new byte[32];
+            Options.RandomNumberGenerator.GetBytes(nonceBytes);
+            var correlationId = TextEncodings.Base64Url.Encode(nonceBytes);
+
+            properties.Items[correlationKey] = correlationId;
+
+            Response.Cookies.Append(correlationKey, correlationId, new CookieOptions {
+                HttpOnly = true,
+                Secure = Request.IsHttps
+            });
+        }
+
+        protected bool ValidateCorrelationId([NotNull] AuthenticationProperties properties) {
+            var correlationKey = "security.Authenticate" + Options.AuthenticationScheme;
+
+            var correlationCookie = Request.Cookies[correlationKey];
+            if (string.IsNullOrWhiteSpace(correlationCookie)) {
+                Logger.LogWarning("{0} cookie not found.", correlationKey);
+
+                return false;
+            }
+
+            Response.Cookies.Delete(correlationKey, new CookieOptions {
+                HttpOnly = true,
+                Secure = Request.IsHttps
+            });
+
+            string correlationExtra;
+            if (!properties.Items.TryGetValue(correlationKey, out correlationExtra)) {
+                Logger.LogWarning("{0} state property not found.", correlationKey);
+
+                return false;
+            }
+
+            properties.Items.Remove(correlationKey);
+
+            if (!string.Equals(correlationCookie, correlationExtra, StringComparison.Ordinal)) {
+                Logger.LogWarning("{0} correlation cookie and state property mismatch.", correlationKey);
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationMiddleware.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationMiddleware.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Authentication.DataHandler;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.DataProtection;
+using Microsoft.Framework.Internal;
+using Microsoft.Framework.Logging;
+using Microsoft.Framework.OptionsModel;
+using Microsoft.Framework.WebEncoders;
+
+namespace AspNet.Security.OpenId {
+    public class OpenIdAuthenticationMiddleware<TOptions> : AuthenticationMiddleware<TOptions>
+        where TOptions : OpenIdAuthenticationOptions, new() {
+        public OpenIdAuthenticationMiddleware(
+            [NotNull] RequestDelegate next,
+            [NotNull] IDataProtectionProvider dataProtectionProvider,
+            [NotNull] ILoggerFactory loggerFactory,
+            [NotNull] IUrlEncoder encoder,
+            [NotNull] IOptions<ExternalAuthenticationOptions> externalOptions,
+            [NotNull] IOptions<TOptions> options,
+            ConfigureOptions<TOptions> configureOptions = null)
+            : base(next, options, loggerFactory, encoder, configureOptions) {
+            if (string.IsNullOrEmpty(Options.SignInScheme)) {
+                Options.SignInScheme = externalOptions.Options.SignInScheme;
+            }
+
+            if (Options.StateDataFormat == null) {
+                Options.StateDataFormat = new PropertiesDataFormat(
+                    dataProtectionProvider.CreateProtector(
+                        GetType().FullName, Options.AuthenticationScheme, "v1"));
+            }
+
+            if (Options.Client == null) {
+                Options.Client = new HttpClient {
+                    Timeout = TimeSpan.FromSeconds(60),
+                    MaxResponseContentBufferSize = 1024 * 1024 * 10
+                };
+
+                Options.Client.DefaultRequestHeaders.UserAgent.ParseAdd("ASP.NET OpenID 2.0 middleware");
+            }
+        }
+
+        protected override AuthenticationHandler<TOptions> CreateHandler() {
+            return new OpenIdAuthenticationHandler<TOptions>();
+        }
+    }
+}

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationOptions.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationOptions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Cryptography;
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Authentication;
+using Microsoft.Framework.Internal;
+
+namespace AspNet.Security.OpenId {
+    public class OpenIdAuthenticationOptions : AuthenticationOptions {
+
+        public OpenIdAuthenticationOptions() {
+            AuthenticationScheme = OpenIdAuthenticationDefaults.AuthenticationScheme;
+            Caption = OpenIdAuthenticationDefaults.AuthenticationScheme;
+        }
+
+        public string Caption {
+            get { return Description.Caption; }
+            set { Description.Caption = value; }
+        }
+
+        public PathString CallbackPath { get; set; } = new PathString("/signin-openid");
+
+        public string SignInScheme { get; set; }
+
+        public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
+
+        public Uri Authority { get; set; }
+
+        public string Realm { get; set; }
+
+        public string Endpoint { get; set; }
+
+        public IOpenIdAuthenticationProvider Provider { get; [param: NotNull] set; } = new OpenIdAuthenticationProvider();
+
+        public RandomNumberGenerator RandomNumberGenerator { get; [param: NotNull] set; } = RandomNumberGenerator.Create();
+
+        public HttpClient Client { get; set; }
+
+        public IDictionary<string, string> Attributes { get; } = new Dictionary<string, string> {
+            ["email"] = "http://axschema.org/contact/email",
+            ["name"] = "http://axschema.org/namePerson",
+            ["first"] = "http://axschema.org/namePerson/first",
+            ["last"] = "http://axschema.org/namePerson/last",
+
+            ["email2"] = "http://schema.openid.net/contact/email",
+            ["name2"] = "http://schema.openid.net/namePerson",
+            ["first2"] = "http://schema.openid.net/namePerson/first",
+            ["last2"] = "http://schema.openid.net/namePerson/last"
+        };
+    }
+}

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationProvider.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+using AspNet.Security.OpenId.Notifications;
+
+namespace AspNet.Security.OpenId {
+    public class OpenIdAuthenticationProvider : IOpenIdAuthenticationProvider {
+        public Func<OpenIdAuthenticatedNotification, Task> OnAuthenticated { get; set; } = notification => Task.FromResult<object>(null);
+        public Func<OpenIdReturnEndpointNotification, Task> OnReturnEndpoint { get; set; } = notification => Task.FromResult<object>(null);
+
+        public virtual Task Authenticated(OpenIdAuthenticatedNotification notification) => OnAuthenticated(notification);
+        public virtual Task ReturnEndpoint(OpenIdReturnEndpointNotification notification) => OnReturnEndpoint(notification);
+    }
+}

--- a/src/AspNet.Security.OpenId/project.json
+++ b/src/AspNet.Security.OpenId/project.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.0.0-alpha1-*",
+    "description": "ASP.NET 5 authentication middleware for OpenID 2.0 providers.",
+    "authors": [ "Kévin Chalet", "Jerrie Pelser" ],
+    "owners": [ "Kévin Chalet", "Jerrie Pelser" ],
+
+    "projectUrl": "https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers",
+    "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+
+    "dependencies": {
+        "System.Collections.Immutable": "1.1.36",
+
+        "Microsoft.AspNet.Authentication": "1.0.0-*",
+        "Microsoft.Framework.NotNullAttribute.Internal": { "type": "build", "version": "1.0.0-*" },
+        "Newtonsoft.Json": "6.0.6"
+    },
+
+    "frameworks": {
+        "dnx451": {
+            "dependencies": {
+                "CsQuery": "1.3.5-*"
+            },
+
+            "frameworkAssemblies": {
+                "System.Net.Http.WebRequest": "",
+                "System.Net.Http": "",
+                "System.Collections": "",
+                "System.Runtime": ""
+            }
+        },
+
+        "dnxcore50": {
+            "dependencies": {
+                "System.Net.Http.WinHttpHandler": "4.0.0-beta-*"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers/issues/3.

For this new OpenID 2.0 authentication middleware, I finally preferred starting from scratch rather than porting the provider developed for `Owin.Security.Providers` but I opted for the same `indirect communication` approach (http://openid.net/specs/openid-authentication-2_0.html#indirect_comm).

Like in the OWIN provider, signature validation is also made directly by the identity provider (http://openid.net/specs/openid-authentication-2_0.html#check_auth).

There are still a few things to fix before merging this PR (e.g logging and documentation), but it sounds promising.

In the meantime, you can test it with Steam (I'll add the Steam provider in another PR), StackExchange and Orange: https://github.com/PinpointTownes/AspNet.Security.OpenId.Providers/tree/sample

/cc @jerriep 