### PR TITLE
Updated Namespaces Identifier

### DIFF
--- a/src/AspNet.Security.OpenId.Steam/SteamAuthenticationConstants.cs
+++ b/src/AspNet.Security.OpenId.Steam/SteamAuthenticationConstants.cs
@@ -10,7 +10,7 @@ namespace AspNet.Security.OpenId.Steam
     {
         public static class Namespaces
         {
-            public const string Identifier = "http://steamcommunity.com/openid/id/";
+            public const string Identifier = "https://steamcommunity.com/openid/id/";
         }
 
         public static class Parameters


### PR DESCRIPTION
- The new Steam update uses HTTPS urls.

The entire userinfo fetch system is currently broken, please consider these changes as soon as possible.