### PR TITLE
Use correct extension method names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddAuthentication(options => { /* Authentication options */ })
-            .UseSteam()
-            .UseOpenId("StackExchange", "StackExchange", options =>
+            .AddSteam()
+            .AddOpenId("StackExchange", "StackExchange", options =>
             {
                 options.Authority = new Uri("https://openid.stackexchange.com/");
                 options.CallbackPath = "/signin-stackexchange";


### PR DESCRIPTION
The extension methods should be AddSteam and AddOpenId, but the readme says UseSteam and UseOpenId