### PR TITLE
Upgrade dependencies to latest

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,9 +9,9 @@
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
-    <AngleSharpVersion>0.9.9</AngleSharpVersion>
+    <AngleSharpVersion>0.13.0</AngleSharpVersion>
     <AspNetCoreVersion>3.0.0</AspNetCoreVersion>
-    <IdentityModelCoreVersion>2.1.4</IdentityModelCoreVersion>
+    <IdentityModelCoreVersion>5.6.0</IdentityModelCoreVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
     <JustEatHttpClientInterceptionVersion>3.0.0</JustEatHttpClientInterceptionVersion>
     <MartinCostelloLoggingXUnitVersion>0.1.0</MartinCostelloLoggingXUnitVersion>

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationConfiguration.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationConfiguration.cs
@@ -14,7 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
-using AngleSharp.Parser.Html;
+using AngleSharp.Html.Parser;
 using JetBrains.Annotations;
 using Microsoft.IdentityModel.Protocols;
 
@@ -254,7 +254,7 @@ namespace AspNet.Security.OpenId
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using (var stream = await response.Content.ReadAsStreamAsync())
-                using (var document = await HtmlParser.ParseAsync(stream, cancellationToken))
+                using (var document = await HtmlParser.ParseDocumentAsync(stream, cancellationToken))
                 {
                     var endpoint = (from element in document.Head.GetElementsByTagName(OpenIdAuthenticationConstants.Metadata.Meta)
                                     let attribute = element.Attributes[OpenIdAuthenticationConstants.Metadata.HttpEquiv]

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationInitializer.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationInitializer.cs
@@ -7,7 +7,7 @@
 using System;
 using System.ComponentModel;
 using System.Net.Http;
-using AngleSharp.Parser.Html;
+using AngleSharp.Html.Parser;
 using AspNet.Security.OpenId;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationOptions.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationOptions.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using AngleSharp.Parser.Html;
+using AngleSharp.Html.Parser;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Protocols;
 


### PR DESCRIPTION
Upgrade AngleSharp to 0.13.0 and Microsoft.IdentityModel.Protocols to 5.6.0.

This fix #74

Cuz AngleSharp drops support for .Net Framework 4.5, .Net Framework minimum requirement moves from *4.5* to *4.6*