### PR TITLE
Restore Newtonsoft.Json

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,7 @@
     <AspNetCoreVersion>3.1.2</AspNetCoreVersion>
     <IdentityModelCoreVersion>5.6.0</IdentityModelCoreVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
+    <JsonNetVersion>10.0.3</JsonNetVersion>
     <JustEatHttpClientInterceptionVersion>3.0.0</JustEatHttpClientInterceptionVersion>
     <MartinCostelloLoggingXUnitVersion>0.1.0</MartinCostelloLoggingXUnitVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>

--- a/src/AspNet.Security.OpenId/AspNet.Security.OpenId.csproj
+++ b/src/AspNet.Security.OpenId/AspNet.Security.OpenId.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AngleSharp" Version="$(AngleSharpVersion)" />
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="$(IdentityModelCoreVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 

--- a/src/AspNet.Security.OpenId/Events/OpenIdAuthenticatedContext.cs
+++ b/src/AspNet.Security.OpenId/Events/OpenIdAuthenticatedContext.cs
@@ -4,12 +4,14 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text.Json;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenId
 {
@@ -57,6 +59,13 @@ namespace AspNet.Security.OpenId
         /// Gets or sets the optional JSON payload extracted from the current request.
         /// This property is not set by the generic middleware but can be used by specialized middleware.
         /// </summary>
-        public JsonDocument User { get; set; }
+        [Obsolete("Use the UserPayload property instead. This property's type will change from JObject to JsonDocument in a future release.")]
+        public JObject User { get; set; } = new JObject();
+
+        /// <summary>
+        /// Gets or sets the optional JSON payload extracted from the current request.
+        /// This property is not set by the generic middleware but can be used by specialized middleware.
+        /// </summary>
+        public JsonDocument UserPayload { get; set; }
     }
 }


### PR DESCRIPTION
Revert breaking change made in #70, instead making the new System.Text.Json support an addition, rather than a replacement.

In a future v4 (or v5) release we can change the type over as originally intended and remove the new alternate `UserProfile` property.