### PR TITLE
Fixed a problem of not recognizing some return AX values that have a …

### DIFF
--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
@@ -277,6 +277,14 @@ namespace AspNet.Security.OpenId
                 Request.Scheme + "://" + Request.Host +
                 OriginalPathBase + Options.CallbackPath;
 
+            var identity = "http://specs.openid.net/auth/2.0/identifier_select";
+            object tmpValue = null;
+            properties.Parameters.TryGetValue(OpenIdAuthenticationConstants.Parameters.Identity, out tmpValue);
+            if(tmpValue != null)
+            {
+                identity = Convert.ToString(tmpValue);
+            }
+
             // Generate a new anti-forgery token.
             GenerateCorrelationId(properties);
 
@@ -284,8 +292,8 @@ namespace AspNet.Security.OpenId
             // See http://openid.net/specs/openid-authentication-2_0.html#requesting_authentication
             var message = new OpenIdAuthenticationMessage
             {
-                ClaimedIdentifier = "http://specs.openid.net/auth/2.0/identifier_select",
-                Identity = "http://specs.openid.net/auth/2.0/identifier_select",
+                ClaimedIdentifier = identity,
+                Identity = identity,
                 Mode = OpenIdAuthenticationConstants.Modes.CheckIdSetup,
                 Namespace = OpenIdAuthenticationConstants.Namespaces.OpenId,
                 Realm = realm,

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationMessage.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationMessage.cs
@@ -211,11 +211,15 @@ namespace AspNet.Security.OpenId
                     continue;
                 }
 
+                var key = $"{OpenIdAuthenticationConstants.Prefixes.OpenId}.{alias}." +
+                                            $"{OpenIdAuthenticationConstants.Suffixes.Value}.{name}";
+                var value = string.Empty;
                 // Exclude attributes whose value is missing.
-                if (!Parameters.TryGetValue($"{OpenIdAuthenticationConstants.Prefixes.OpenId}.{alias}." +
-                                            $"{OpenIdAuthenticationConstants.Suffixes.Value}.{name}", out string value))
+                if (!Parameters.TryGetValue(key, out value))
                 {
-                    continue;
+                    key += ".1";
+                    if (!Parameters.TryGetValue(key, out value))
+                        continue;
                 }
 
                 // Exclude attributes whose value is null or empty.


### PR DESCRIPTION
AX values from some OpenID provider are like this:
Key: openid.ax.type.ext0 | Value: userkey
Key: openid.ax.value.ext0.1 | Value: 19