### PR TITLE
Move build Id logic to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,23 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
 
+    # Arcade only allows the revision to contain up to two characters, and GitHub Actions does not roll-over
+    # build numbers every day like Azure DevOps does. To balance these two requirements, set the official
+    # build ID to be the same format as the built-in default from Arcade, except with the revision number
+    # being the number of the quarter hour of the current time of day (24 * 4 = 96, which is less than 100).
+    # So a build between 00:00 and 00:14 would have a revision of 1, and a build between 23:45 and 23:59:59
+    # would have a revision of 97.
+    - name: Set Build ID
+      if: ${{ startsWith(github.ref, 'refs/pull/') == false }}
+      shell: pwsh
+      run: |
+        $Now = (Get-Date).ToUniversalTime()
+        $Hours = $Now.Hour * 4
+        $QuarterHours = [Math]::Floor($Now.Minute / 15.0)
+        $Revision = $Hours + $QuarterHours + 1
+        $BuildId = $Now.ToString("yyyyMMdd") + "." + $Revision
+        Write-Host "::set-env name=_AspNetContribBuildNumber::${BuildId}"
+
     - name: Build, Test and Package
       run: eng\common\CIBuild.cmd -configuration Release -prepareMachine
       if: ${{ runner.os == 'Windows' }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,22 +21,13 @@
   </PropertyGroup>
 
   <!--
-    Arcade only allows the revision to contain up to two characters, and GitHub Actions does not roll-over
-    build numbers every day like Azure DevOps does. To balance these two requirements, set the official
-    build ID to be the same format as the built-in default from Arcade, except with the revision number
-    being the number of the quarter hour of the current time of day (24 * 4 = 96, which is less than 100).
-    So a build between 00:00 and 00:14 would have a revision of 1, and a build between 23:45 and 23:59:59
-    would have a revision of 97.
+    These are set per-project so versioning is applied correctly, but are not set globally otherwise
+    the Arcade SDK will attempt to publish artifacts such as symbols to Microsoft's servers.
   -->
 
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' == 'true' AND '$(GITHUB_REF.StartsWith(`refs/pull/`))' == 'false' ">
-    <_Hours>$([MSBuild]::Multiply($([System.DateTime]::Now.ToString(HH)), 4))</_Hours>
-    <_QuarterHours>$([MSBuild]::Divide($([System.DateTime]::Now.ToString(mm)), 15))</_QuarterHours>
-    <_QuarterHours>$([System.Math]::Floor($(_QuarterHours)))</_QuarterHours>
-    <_GitHubActionsBuildRevision>$([MSBuild]::Add($(_Hours), $(_QuarterHours)))</_GitHubActionsBuildRevision>
-    <_GitHubActionsBuildRevision>$([MSBuild]::Add($(_GitHubActionsBuildRevision), 1))</_GitHubActionsBuildRevision>
     <OfficialBuild>true</OfficialBuild>
-    <OfficialBuildId Condition=" '$(OfficialBuild)' == 'true' ">$([System.DateTime]::Now.ToString(yyyyMMdd)).$(_GitHubActionsBuildRevision)</OfficialBuildId>
+    <OfficialBuildId>$(_AspNetContribBuildNumber)</OfficialBuildId>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Move the logic for calculating the build Id into the GitHub Actions workflow so the same Id is used consistently during a build, rather than changing if a build occurs across a 5 minute build boundary.
