### PR TITLE
Always publish logs and test results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
 
     - name: Publish logs
       uses: actions/upload-artifact@v1
+      if: ${{ always() }}
       with:
         name: logs-${{ matrix.os_name }}
         path: ./artifacts/log/Release
@@ -72,6 +73,7 @@ jobs:
 
     - name: Publish test results
       uses: actions/upload-artifact@v1
+      if: ${{ always() }}
       with:
         name: testresults-${{ matrix.os_name }}
         path: ./artifacts/TestResults/Release


### PR DESCRIPTION
Always try to publish build logs and test results, even if the build itself fails.
