### PR TITLE
Use GITHUB_ENV not GITHUB_PATH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         $QuarterHours = [Math]::Floor($Now.Minute / 15.0)
         $Revision = $Hours + $QuarterHours + 1
         $BuildId = $Now.ToString("yyyyMMdd") + "." + $Revision
-        Write-Output "_AspNetContribBuildNumber=${BuildId}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        Write-Output "_AspNetContribBuildNumber=${BuildId}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Build, Test and Package
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
That's what happens when the example of how to do one thing is in the section about how to do something else.
