### PR TITLE
Add DefaultNetCoreTargetFramework property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>
+    <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/Mvc.Client/Mvc.Client.csproj
+++ b/samples/Mvc.Client/Mvc.Client.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <IsShipping>false</IsShipping>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <UserSecretsId>AspNet.Security.OpenId.Providers.Mvc.Client</UserSecretsId>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OpenId.Steam/AspNet.Security.OpenId.Steam.csproj
+++ b/src/AspNet.Security.OpenId.Steam/AspNet.Security.OpenId.Steam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OpenId/AspNet.Security.OpenId.csproj
+++ b/src/AspNet.Security.OpenId/AspNet.Security.OpenId.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/AspNet.Security.OpenId.Providers.Tests/AspNet.Security.OpenId.Providers.Tests.csproj
+++ b/test/AspNet.Security.OpenId.Providers.Tests/AspNet.Security.OpenId.Providers.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>AspNet.Security.OpenId</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1707</NoWarn>


### PR DESCRIPTION
Inspired by the ASP.NET Core repo, add a new DefaultNetCoreTargetFramework MSBuild property and use that to specify the target framework in each project.

This should make future changes for .NET 6 and beyond easier as we won't necessarily need to touch every project file to perform the update.
