### PR TITLE
Bump version to 6.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,8 +53,6 @@
 
   <PropertyGroup>
     <EnablePackageValidation>$(IsPackable)</EnablePackageValidation>
-    <!-- TODO Remove suppression once 6.0.0 is released. -->
-    <NoWarn>$(NoWarn);PKV006</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,10 +3,9 @@
   <PropertyGroup>
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <!-- TODO Baseline to 6.0.0 once released -->
-    <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>6.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>


### PR DESCRIPTION
* Bump version to `6.0.1` for next release.
* Resolve TODOs from `6.0.0` release.
