### PR TITLE
add support old PHP OpenID provider.

### DIFF
--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
@@ -276,6 +276,14 @@ public partial class OpenIdAuthenticationHandler<TOptions> : RemoteAuthenticatio
             Request.Scheme + "://" + Request.Host +
             OriginalPathBase + Options.CallbackPath;
 
+        var identity = "http://specs.openid.net/auth/2.0/identifier_select";
+        object? tmpValue;
+        properties.Parameters.TryGetValue(OpenIdAuthenticationConstants.Parameters.Identity, out tmpValue);
+        if (tmpValue != null)
+        {
+            identity = tmpValue.ToString();
+        }
+
         // Generate a new anti-forgery token.
         GenerateCorrelationId(properties);
 
@@ -283,8 +291,8 @@ public partial class OpenIdAuthenticationHandler<TOptions> : RemoteAuthenticatio
         // See http://openid.net/specs/openid-authentication-2_0.html#requesting_authentication
         var message = new OpenIdAuthenticationMessage
         {
-            ClaimedIdentifier = "http://specs.openid.net/auth/2.0/identifier_select",
-            Identity = "http://specs.openid.net/auth/2.0/identifier_select",
+            ClaimedIdentifier = identity,
+            Identity = identity,
             Mode = OpenIdAuthenticationConstants.Modes.CheckIdSetup,
             Namespace = OpenIdAuthenticationConstants.Namespaces.OpenId,
             Realm = realm,

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationMessage.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationMessage.cs
@@ -209,10 +209,14 @@ public class OpenIdAuthenticationMessage
             }
 
             // Exclude attributes whose value is missing.
-            if (!Parameters.TryGetValue($"{OpenIdAuthenticationConstants.Prefixes.OpenId}.{alias}." +
-                                        $"{OpenIdAuthenticationConstants.Suffixes.Value}.{name}", out string? value))
+            var key = $"{OpenIdAuthenticationConstants.Prefixes.OpenId}.{alias}." +
+                                            $"{OpenIdAuthenticationConstants.Suffixes.Value}.{name}";
+            string? value;
+            if (!Parameters.TryGetValue(key, out value))
             {
-                continue;
+                key += ".1";
+                if (!Parameters.TryGetValue(key, out value))
+                    continue;
             }
 
             // Exclude attributes whose value is null or empty.


### PR DESCRIPTION
AX values from some OpenID providers are like this:
```
Key: openid.ax.type.ext0 | Value: userkey
Key: openid.ax.value.ext0.1 | Value: 22
```