### PR TITLE
Fix typo, steam response is "steamid", not steamids.

### DIFF
--- a/src/AspNet.Security.OpenId.Steam/SteamAuthenticationConstants.cs
+++ b/src/AspNet.Security.OpenId.Steam/SteamAuthenticationConstants.cs
@@ -17,7 +17,7 @@ public static class SteamAuthenticationConstants
     public static class Parameters
     {
         public const string Key = "key";
-        public const string SteamId = "steamids";
+        public const string SteamId = "steamid";
         public const string Response = "response";
         public const string Players = "players";
         public const string Name = "personaname";


### PR DESCRIPTION
Fix typo, Steam's response is "steamid", not "steamids".