### PR TITLE
Update to ASP.NET Core 8 preview 5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,11 +5,11 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.4.23260.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.4.23260.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.5.23302.2" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="6.10.0" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0-preview.4.23259.5" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0-preview.5.23280.8" />
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>5</PreReleaseVersionIteration>
     <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.4.23260.5"
+    "version": "8.0.100-preview.5.23303.2"
   },
 
   "tools": {
-    "dotnet": "8.0.100-preview.4.23260.5"
+    "dotnet": "8.0.100-preview.5.23303.2"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OpenId.Steam/SteamAuthenticationHandler.cs
+++ b/src/AspNet.Security.OpenId.Steam/SteamAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class SteamAuthenticationHandler : OpenIdAuthenticationHandler<St
     public SteamAuthenticationHandler(
         [NotNull] IOptionsMonitor<SteamAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public class OpenIdAuthenticationHandler : OpenIdAuthenticationHandler<OpenIdAut
     public OpenIdAuthenticationHandler(
         [NotNull] IOptionsMonitor<OpenIdAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 }
@@ -32,9 +31,8 @@ public partial class OpenIdAuthenticationHandler<TOptions> : RemoteAuthenticatio
     public OpenIdAuthenticationHandler(
         [NotNull] IOptionsMonitor<TOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 
@@ -419,14 +417,14 @@ public partial class OpenIdAuthenticationHandler<TOptions> : RemoteAuthenticatio
 
             // Stop processing the assertion if the mandatory is_valid
             // parameter was missing from the response body.
-            if (!parameters.ContainsKey(OpenIdAuthenticationConstants.Parameters.IsValid))
+            if (!parameters.TryGetValue(OpenIdAuthenticationConstants.Parameters.IsValid, out var isValid))
             {
                 Log.InvalidCheckAuthenticationResponse(Logger);
                 return false;
             }
 
             // Stop processing the assertion if the authentication server declared it as invalid.
-            if (!string.Equals(parameters[OpenIdAuthenticationConstants.Parameters.IsValid], "true", StringComparison.Ordinal))
+            if (!string.Equals(isValid, "true", StringComparison.Ordinal))
             {
                 Log.InvalidSecurityAssertion(Logger);
                 return false;


### PR DESCRIPTION
- Update to preview 5 of ASP.NET Core 8.
- Remove now-obsolete use of `ISystemClock`.
- Fix code analysis warning by using `TryGetValue()`.
