### PR TITLE
Update to ASP.NET Core 8 RC 1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,11 +5,11 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.7.23375.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="6.10.0" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0-rc.1.23419.4" />
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,9 +6,9 @@
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
-    <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
+    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseBrandingLabel>Release Candidate $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.7.23376.3"
+    "version": "8.0.100-rc.1.23455.8"
   },
 
   "tools": {
-    "dotnet": "8.0.100-preview.7.23376.3"
+    "dotnet": "8.0.100-rc.1.23455.8"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationInitializer.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationInitializer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -112,7 +112,7 @@ public class OpenIdAuthenticationInitializer<TOptions, THandler> : IPostConfigur
                         throw new ArgumentException("The authority cannot contain a fragment or a query string.", nameof(options));
                     }
 
-                    if (!options.Authority.OriginalString.EndsWith('/', StringComparison.Ordinal))
+                    if (!options.Authority.OriginalString.EndsWith('/'))
                     {
                         options.Authority = new Uri(options.Authority.OriginalString + "/", UriKind.Absolute);
                     }

--- a/src/AspNet.Security.OpenId/OpenIdAuthenticationInitializer.cs
+++ b/src/AspNet.Security.OpenId/OpenIdAuthenticationInitializer.cs
@@ -112,7 +112,7 @@ public class OpenIdAuthenticationInitializer<TOptions, THandler> : IPostConfigur
                         throw new ArgumentException("The authority cannot contain a fragment or a query string.", nameof(options));
                     }
 
-                    if (!options.Authority.OriginalString.EndsWith("/", StringComparison.Ordinal))
+                    if (!options.Authority.OriginalString.EndsWith('/', StringComparison.Ordinal))
                     {
                         options.Authority = new Uri(options.Authority.OriginalString + "/", UriKind.Absolute);
                     }


### PR DESCRIPTION
Update to release candidate 1 of ASP.NET Core 8.

Unless there's any new analyzer warnings or other issues, this should be good to rebuild, move out of draft and merge when it's available tomorrow.
