### PR TITLE
Update to ASP.NET Core 8 RC 2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,14 +2,14 @@
 
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="0.13.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
-    <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.2" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0" />
+    <PackageVersion Include="JustEat.HttpClientInterception" Version="4.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="6.10.0" />
-    <PackageVersion Include="Shouldly" Version="4.1.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.2.23480.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.2.23480.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="7.0.0" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0-rc.2.23479.6" />
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <PreReleaseBrandingLabel>Release Candidate $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23463.5",
+    "version": "8.0.100-rc.2.23502.2",
     "allowPrerelease": true,
     "rollForward": "major"
   },
 
   "tools": {
-    "dotnet": "8.0.100-rc.1.23463.5"
+    "dotnet": "8.0.100-rc.2.23502.2"
   },
 
   "msbuild-sdks": {


### PR DESCRIPTION
- Update to RC 2 of ASP.NET Core 8.
- Update NuGet packages to their latest versions.
