### PR TITLE
AoT support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,6 +54,14 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(IsPackable)' == 'true' ">
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
   <PropertyGroup>
     <EnablePackageValidation>$(IsPackable)</EnablePackageValidation>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.0.6-alpha-330" />
+    <PackageVersion Include="AngleSharp" Version="1.0.6" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.0.5" />
+    <PackageVersion Include="AngleSharp" Version="1.0.6-alpha-330" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />


### PR DESCRIPTION
Add support for native AoT for the libraries.

Tested the same way as https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/pull/815 with the same results.

Depends on stable release of AngleSharp 1.0.6 (see https://github.com/AngleSharp/AngleSharp/pull/1144).
