### PR TITLE
Bump GitHub Actions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "06:30"
+    timezone: Europe/London
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "06:30"
+    timezone: Europe/London
+  open-pull-requests-limit: 99
+  ignore:
+    - dependency-name: "Microsoft.AspNetCore.Mvc.Testing"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "Microsoft.AspNetCore.TestHost"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "Microsoft.IdentityModel.Protocols"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
+    outputs:
+      dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -37,10 +40,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      id: setup-dotnet
 
     - name: Setup NuGet
-      uses: nuget/setup-nuget@v1
+      uses: nuget/setup-nuget@a21f25cd3998bf370fde17e3f1b4c12c175172f9 # v2.0.0
       with:
         nuget-version: '5.11.0'
 
@@ -71,20 +78,20 @@ jobs:
       run: ./eng/common/cibuild.sh -configuration Release -prepareMachine
 
     - name: Publish logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       if: ${{ always() }}
       with:
         name: logs-${{ matrix.os_name }}
         path: ./artifacts/log/Release
 
     - name: Publish NuGet packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/packages/Release/Shipping
 
     - name: Publish test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       if: ${{ always() }}
       with:
         name: testresults-${{ matrix.os_name }}
@@ -96,12 +103,14 @@ jobs:
     steps:
 
     - name: Download packages
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
       with:
         name: packages-windows
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -120,7 +129,7 @@ jobs:
         }
 
   publish-myget:
-    needs: validate-packages
+    needs: [ build, validate-packages ]
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
@@ -131,18 +140,22 @@ jobs:
     steps:
 
     - name: Download packages
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
       with:
         name: packages-windows
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to aspnet-contrib MyGet
-      run: nuget push "*.nupkg" -ApiKey ${{ secrets.MYGET_API_KEY }} -SkipDuplicate -Source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
+      env:
+        MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
+      run: nuget push "*.nupkg" -ApiKey "${MYGET_API_KEY}" -SkipDuplicate -Source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
 
   publish-nuget:
-    needs: validate-packages
+    needs: [ build, validate-packages ]
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
@@ -150,12 +163,16 @@ jobs:
     steps:
 
     - name: Download packages
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
       with:
         name: packages-windows
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to NuGet.org
-      run: nuget push "*.nupkg" -ApiKey ${{ secrets.NUGET_API_KEY }} -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: nuget push "*.nupkg" -ApiKey "${NUGET_API_KEY}" -SkipDuplicate -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
- Add dependabot to keep GitHub Actions and most NuGet packages up-to-date.
- Update GitHub Actions to their latest versions to resolve Node.js v16 deprecation warnings.
- Pin GitHub Actions by SHA.
- Use a repeatable .NET SDK version.
