### PR TITLE
Ignore AngleSharp updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,5 @@ updates:
     - dependency-name: "Microsoft.AspNetCore.TestHost"
       update-types: ["version-update:semver-major"]
     - dependency-name: "Microsoft.IdentityModel.Protocols"
+    - dependency-name: "Microsoft.DotNet.Arcade.Sdk"
+    - dependency-name: "Microsoft.DotNet.Helix.Sdk"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 99
   ignore:
+    - dependency-name: "AngleSharp"
     - dependency-name: "Microsoft.AspNetCore.Mvc.Testing"
       update-types: ["version-update:semver-major"]
     - dependency-name: "Microsoft.AspNetCore.TestHost"


### PR DESCRIPTION
Ignore as this is a dependencies of the published libraries. I forgot that when I added the dependabot configuration.
