### PR TITLE
Fix NuGet badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ See the [/samples](https://github.com/aspnet-contrib/AspNet.Security.OpenId.Prov
 
 **AspNet.Security.OpenId.Providers** is actively maintained by:
 
-  * **[Kévin Chalet](https://github.com/kevinchalet)** ([@kevin_chalet](https://twitter.com/kevin_chalet)).
-  * **[Martin Costello](https://github.com/martincostello)** ([@martin_costello](https://twitter.com/martin_costello)).
+- **[Kévin Chalet](https://github.com/kevinchalet)** ([@kevin_chalet](https://twitter.com/kevin_chalet)).
+- **[Martin Costello](https://github.com/martincostello)** ([@martin_costello](https://twitter.com/martin_costello)).
 
 We would love it if you could help contributing to this repository.
 
@@ -62,9 +62,9 @@ If a provider you're looking for does not exist, consider making a PR to add one
 
 | Provider | Stable | Nightly | Documentation |
 |:-:|:-:|:-:|:-:|
-| OpenId | [![NuGet](https://buildstats.info/nuget/AspNet.Security.OpenId?includePreReleases=false)](https://www.nuget.org/packages/AspNet.Security.OpenId/ "Download AspNet.Security.OpenId from NuGet.org") | [![MyGet](https://buildstats.info/myget/aspnet-contrib/AspNet.Security.OpenId?includePreReleases=true)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OpenId "Download AspNet.Security.OpenId from MyGet.org") | N/A |
-| Steam | [![NuGet](https://buildstats.info/nuget/AspNet.Security.OpenId.Steam?includePreReleases=false)](https://www.nuget.org/packages/AspNet.Security.OpenId.Steam/ "Download AspNet.Security.OpenId.Steam from NuGet.org") | [![MyGet](https://buildstats.info/myget/aspnet-contrib/AspNet.Security.OpenId.Steam?includePreReleases=true)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OpenId.Steam "Download AspNet.Security.OpenId.Steam from MyGet.org") | [Documentation](https://steamcommunity.com/dev "Steam developer documentation") |
+| OpenId | [![NuGet](https://img.shields.io/nuget/v/AspNet.Security.OpenId?logo=nuget&label=NuGet&color=blue)](https://www.nuget.org/packages/AspNet.Security.OpenId/ "Download AspNet.Security.OpenId from NuGet.org") | [![MyGet](https://img.shields.io/myget/aspnet-contrib/vpre/AspNet.Security.OpenId?logo=nuget&label=MyGet&color=blue)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OpenId "Download AspNet.Security.OpenId from MyGet.org") | N/A |
+| Steam | [![NuGet](https://img.shields.io/nuget/v/AspNet.Security.OpenId.Steam?logo=nuget&label=NuGet&color=blue)](https://www.nuget.org/packages/AspNet.Security.OpenId.Steam/ "Download AspNet.Security.OpenId.Steam from NuGet.org") | [![MyGet](https://img.shields.io/myget/aspnet-contrib/vpre/AspNet.Security.OpenId.Steam?logo=nuget&label=MyGet&color=blue)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OpenId.Steam "Download AspNet.Security.OpenId.Steam from MyGet.org") | [Documentation](https://steamcommunity.com/dev "Steam developer documentation") |
 
 <!--
-| CHANGEME | [![NuGet](https://buildstats.info/nuget/AspNet.Security.OpenId.CHANGEME?includePreReleases=false)](https://www.nuget.org/packages/AspNet.Security.OpenId.CHANGEME/ "Download AspNet.Security.OpenId.CHANGEME from NuGet.org") | [![MyGet](https://buildstats.info/myget/aspnet-contrib/AspNet.Security.OpenId.CHANGEME?includePreReleases=true)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OpenId.CHANGEME "Download AspNet.Security.OpenId.CHANGEME from MyGet.org") | [Documentation](CHANGEME "CHANGEME developer documentation") |
+| CHANGEME | [![NuGet](https://img.shields.io/nuget/v/AspNet.Security.OpenId.CHANGEME?logo=nuget&label=NuGet&color=blue)](https://www.nuget.org/packages/AspNet.Security.OpenId.CHANGEME/ "Download AspNet.Security.OpenId.CHANGEME from NuGet.org") | [![MyGet](https://img.shields.io/myget/aspnet-contrib/vpre/AspNet.Security.OpenId.CHANGEME?logo=nuget&label=MyGet&color=blue)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OpenId.CHANGEME "Download AspNet.Security.OpenId.CHANGEME from MyGet.org") | [Documentation](CHANGEME "CHANGEME developer documentation") |
 -->


### PR DESCRIPTION
- Use shields.io for NuGet badges.
- Fix markdownlint warning.
