### PR TITLE
Fix package validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,11 @@ jobs:
       with:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
+    - name: Setup .NET 6 SDK
+      uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+      with:
+        dotnet-version: '6.0.x'
+
     - name: Validate NuGet packages
       shell: pwsh
       run: |


### PR DESCRIPTION
Looks like the GitHub Actions hosted runner doesn't come with .NET 6 anymore.

See aspnet-contrib/AspNet.Security.OAuth.Providers#960.
