### PR TITLE
Fix package publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Push NuGet packages to aspnet-contrib MyGet
       env:
         MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
-      run: nuget push "*.nupkg" -ApiKey "${MYGET_API_KEY}" -SkipDuplicate -Source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key "${MYGET_API_KEY}" --skip-duplicate --source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
 
   publish-nuget:
     needs: [ build, validate-packages ]
@@ -200,4 +200,4 @@ jobs:
     - name: Push NuGet packages to NuGet.org
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: nuget push "*.nupkg" -ApiKey "${NUGET_API_KEY}" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key "${NUGET_API_KEY}" --skip-duplicate --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
NuGet doesn't appear to be installed on the hosted runners anymore so go back to publishing through `dotnet nuget`.
