### PR TITLE
Fix steam auth by specifying referer and origin headers in backchannel

### DIFF
--- a/src/AspNet.Security.OpenId.Steam/SteamAuthenticationHandler.cs
+++ b/src/AspNet.Security.OpenId.Steam/SteamAuthenticationHandler.cs
@@ -77,6 +77,11 @@ public partial class SteamAuthenticationHandler : OpenIdAuthenticationHandler<St
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(OpenIdAuthenticationConstants.Media.Json));
 
+        // Add referer and origin header so steam does not 403 the request
+        // Started to be a requirement on the 12th of February 2025
+        Options.Backchannel.DefaultRequestHeaders.Add("referer", "https://steamcommunity.com");
+        Options.Backchannel.DefaultRequestHeaders.Add("origin", "https://steamcommunity.com");
+
         // Return the authentication ticket as-is if the userinfo request failed.
         using var response = await Options.Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
         if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OpenId.Steam/SteamAuthenticationOptions.cs
+++ b/src/AspNet.Security.OpenId.Steam/SteamAuthenticationOptions.cs
@@ -12,6 +12,14 @@ public class SteamAuthenticationOptions : OpenIdAuthenticationOptions
     {
         Authority = new Uri(SteamAuthenticationDefaults.Authority);
         CallbackPath = SteamAuthenticationDefaults.CallbackPath;
+        Backchannel = new HttpClient
+        {
+            DefaultRequestHeaders =
+            {
+                { "referer", "https://steamcommunity.com" },
+                { "origin", "https://steamcommunity.com" }
+            }
+        };
     }
 
     /// <summary>

--- a/src/AspNet.Security.OpenId.Steam/SteamAuthenticationOptions.cs
+++ b/src/AspNet.Security.OpenId.Steam/SteamAuthenticationOptions.cs
@@ -12,14 +12,6 @@ public class SteamAuthenticationOptions : OpenIdAuthenticationOptions
     {
         Authority = new Uri(SteamAuthenticationDefaults.Authority);
         CallbackPath = SteamAuthenticationDefaults.CallbackPath;
-        Backchannel = new HttpClient
-        {
-            DefaultRequestHeaders =
-            {
-                { "referer", "https://steamcommunity.com" },
-                { "origin", "https://steamcommunity.com" }
-            }
-        };
     }
 
     /// <summary>


### PR DESCRIPTION
Adds referer and origin headers in Backchannel within default SteamAuthenticationOptions. This seems to resolve the steam auth login issue which started today morning.

Resolves following issue post: https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers/issues/275