### PR TITLE
Harden workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ env:
   NUGET_XMLDOC_MODE: skip
   TERM: xterm
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
@@ -46,6 +45,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
@@ -69,12 +72,12 @@ jobs:
         Write-Output "_AspNetContribBuildNumber=${BuildId}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Build, Test and Package
-      if: ${{ runner.os == 'Windows' }}
+      if: runner.os == 'Windows'
       run: eng\common\CIBuild.cmd -configuration Release -prepareMachine
 
     - name: Build, Test and Package
       shell: pwsh
-      if: ${{ runner.os != 'Windows' }}
+      if: runner.os != 'Windows'
       run: ./eng/common/cibuild.sh -configuration Release -prepareMachine
 
     - name: Attest artifacts
@@ -93,7 +96,7 @@ jobs:
 
     - name: Publish logs
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      if: ${{ always() }}
+      if: ${{ !cancelled() }}
       with:
         name: logs-${{ matrix.os_name }}
         path: ./artifacts/log/Release
@@ -106,7 +109,7 @@ jobs:
 
     - name: Publish test results
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      if: ${{ always() }}
+      if: ${{ !cancelled() }}
       with:
         name: testresults-${{ matrix.os_name }}
         path: ./artifacts/TestResults/Release
@@ -166,8 +169,9 @@ jobs:
 
     - name: Push NuGet packages to aspnet-contrib MyGet
       env:
-        MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
-      run: dotnet nuget push "*.nupkg" --api-key "${MYGET_API_KEY}" --skip-duplicate --source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
+        API_KEY: ${{ secrets.MYGET_API_KEY }}
+        SOURCE: https://www.myget.org/F/aspnet-contrib/api/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}"
 
   publish-nuget:
     needs: [ build, validate-packages ]
@@ -189,5 +193,6 @@ jobs:
 
     - name: Push NuGet packages to NuGet.org
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "*.nupkg" --api-key "${NUGET_API_KEY}" --skip-duplicate --source https://api.nuget.org/v3/index.json
+        API_KEY: ${{ secrets.NUGET_API_KEY }}
+        SOURCE: https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}"

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -1,0 +1,70 @@
+name: code-scan
+
+on:
+  push:
+    branches: [ dev* ]
+  pull_request:
+    branches: [ dev* ]
+  schedule:
+    - cron: '0 12 * * MON'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+
+  code-ql:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'actions', 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+      with:
+        build-mode: none
+        languages: ${{ matrix.language }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+      with:
+        category: '/language:${{ matrix.language }}'
+
+  zizmor:
+    runs-on: ubuntu-latest
+
+    env:
+      ZIZMOR_VERSION: '1.12.1'
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
+
+    - name: Scan workflows with zizmor
+      uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2
+      with:
+        version: ${{ env.ZIZMOR_VERSION }}

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -11,12 +11,10 @@ on:
         type: choice
         options:
           - 'dev'
-          - 'dev-v9'
+          - 'dev-v10'
         default: 'dev'
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   update-sdk:


### PR DESCRIPTION
- Make permissions job-level rather than workflow-level.
- Do not persist Git credentials.
- Simplify some conditions.
- Use environment variables to make code to push NuGet packages consistent.
- Update branch name.
- Add workflow to scan actions and C# code with CodeQL.
- Add job to scan workflows with zizmor.
