### PR TITLE
Use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,11 @@ jobs:
 
   publish-nuget:
     needs: [ build, validate-packages ]
+    environment:
+      name: NuGet.org
+      url: https://www.nuget.org/profiles/aspnet-contrib
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
@@ -191,8 +196,14 @@ jobs:
       with:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
+    - name: NuGet log in
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push NuGet packages to NuGet.org
       env:
-        API_KEY: ${{ secrets.NUGET_API_KEY }}
+        API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         SOURCE: https://api.nuget.org/v3/index.json
       run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}"


### PR DESCRIPTION
Switch to using GitHub OIDC for pushing packages to NuGet.org with [Trusted Publishing](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/).

@kevinchalet Could you update the repository configuration so this will work please?

Steps:

1. Create an environment called `NuGet.org`
2. Add a secret to the `NuGet.org` environment named `NUGET_USER` whose value is my NuGet.org username (it's not a secret, but I think it's better not to be hard-coded in the workflow 😃)
3. (Optionally) delete the `NUGET_API_KEY` secret
