### PR TITLE
Bump AngleSharp to 1.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.3.0" />
+    <PackageVersion Include="AngleSharp" Version="1.5.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />


### PR DESCRIPTION
Upgrade AngleSharp dependency to 1.5.0 to address GHSA-pgww-w46g-26qg.
